### PR TITLE
Gem install 1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,3 +60,6 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem 'dotenv-rails' 
+gem 'line-bot-api'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,10 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.6)
     crass (1.0.6)
+    dotenv (2.7.5)
+    dotenv-rails (2.7.5)
+      dotenv (= 2.7.5)
+      railties (>= 3.2, < 6.1)
     erubi (1.9.0)
     execjs (2.7.0)
     ffi (1.12.2)
@@ -83,6 +87,7 @@ GEM
     io-like (0.3.1)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
+    line-bot-api (1.14.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -195,7 +200,9 @@ DEPENDENCIES
   capybara (>= 2.15)
   chromedriver-helper
   coffee-rails (~> 4.2)
+  dotenv-rails
   jbuilder (~> 2.5)
+  line-bot-api
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   puma (~> 3.11)


### PR DESCRIPTION
## What
- gem 'dotenv-rails' 
- gem 'line-bot-api'
- 上記2つのインストーーーーール！

## Why
- gem dotenv-railsのイントール理由
    -  環境変数を扱うために使用するgem
    - この教材では LINEのアクセストークンなど、厳重に管理する必要があるので
- gem line-bot-apiはapi利用のため